### PR TITLE
Logarithmic Scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Dependency updates
   - toml 0.4 -> 0.5
   - vulkano-glyph 0.3.0 -> 0.4.0
+- Logarithmic scale, FFT updates
 
 ## 0.1.0
 ### Added

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -114,7 +114,7 @@ pub enum RingState {
 pub struct SimpleSource {
     name: Box<String>,
     index: u32,
-    rate: u32,
+    pub rate: u32,
     channels: u8,
     sample_format: Format,
 }

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -243,13 +243,14 @@ void main() {
     uint lidx = gl_LocalInvocationID.x;
     uint num_groups = gl_NumWorkGroups.x;
     uint woven = widx + lidx * num_groups;
-    uint conjugate_index = woven + fft.lin_bins / 2;
-    Complex l = left_chan.data[conjugate_index];
-    Complex r = right_chan.data[conjugate_index];
-    float mag_l = mag(l);
-    float mag_r = mag(r);
-    float phase_l = phase(l);
-    float phase_r = phase(r);
+    uint conjugate_index = fft.lin_bins - woven;
+    Complex conj_l = left_chan.data[conjugate_index];
+    Complex conj_r = right_chan.data[conjugate_index];
+    uint complex_index = woven;
+    Complex com_l = left_chan.data[complex_index];
+    Complex com_r = right_chan.data[complex_index];
+    float mag_l = (mag(com_l) + mag(conj_l)) * 0.5;
+    float mag_r = (mag(com_r) + mag(conj_r)) * 0.5;
     float mix_fac;
     if (mag_l == 0.0) {
         mix_fac = 1.0;

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -237,7 +237,11 @@ float norm_tan(float unnormed);
 
 void main() {
     uint gidx = gl_GlobalInvocationID.x;
-    uint conjugate_index = gidx + fft.lin_bins / 2;
+    uint widx = gl_WorkGroupID.x;
+    uint lidx = gl_LocalInvocationID.x;
+    uint num_groups = gl_NumWorkGroups.x;
+    uint woven = widx + lidx * num_groups;
+    uint conjugate_index = woven + fft.lin_bins / 2;
     Complex l = left_chan.data[conjugate_index];
     Complex r = right_chan.data[conjugate_index];
     float mag_l = pow((pow(l.real, 2.0) + pow(l.imag, 2.0)), 0.5);
@@ -256,7 +260,7 @@ void main() {
                         0.1 * pow(mag_l * mag_r, 0.5),
                         3.0 *(mag_l - 1.4),
                         1.0);
-    imageStore(out_img, ivec2(0, int(gl_GlobalInvocationID.x)), out_col);
+    imageStore(out_img, ivec2(0, woven), out_col);
 }
 
 float norm_tan(float unnormed) {

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -176,8 +176,11 @@ impl AudioTexTap {
                     compute_queue.family(),
                 )
                 .unwrap();
+
+                assert_eq!(source.tex_height as u32 % channel_combine::LOCAL_SIZE_X, 0);
+                let dispatch_x = source.tex_height as u32 / channel_combine::LOCAL_SIZE_X;
                 let cb = cb
-                    .dispatch([64 as u32, 1, 1], pipeline.clone(), set.clone(), ())
+                    .dispatch([dispatch_x, 1, 1], pipeline.clone(), set.clone(), ())
                     .unwrap()
                     .build()
                     .unwrap();
@@ -204,6 +207,7 @@ impl Drop for AudioTexTap {
 }
 
 mod channel_combine {
+    pub static LOCAL_SIZE_X: u32 = 16; // this must match local size
     vulkano_shaders::shader! {
         ty: "compute",
         src: "

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -234,6 +234,8 @@ layout (push_constant) uniform PushConstant {
 } fft;
 
 float norm_tan(float unnormed);
+float mag(Complex c);
+float phase(Complex c);
 
 void main() {
     uint gidx = gl_GlobalInvocationID.x;
@@ -244,10 +246,10 @@ void main() {
     uint conjugate_index = woven + fft.lin_bins / 2;
     Complex l = left_chan.data[conjugate_index];
     Complex r = right_chan.data[conjugate_index];
-    float mag_l = pow((pow(l.real, 2.0) + pow(l.imag, 2.0)), 0.5);
-    float mag_r = pow((pow(r.real, 2.0) + pow(r.imag, 2.0)), 0.5);
-    float phase_l = l.real != 0.0 ? norm_tan(atan(l.imag / l.real)) : 0.0;
-    float phase_r = r.real != 0.0 ? norm_tan(atan(r.imag / r.real)) : 0.0;
+    float mag_l = mag(l);
+    float mag_r = mag(r);
+    float phase_l = phase(l);
+    float phase_r = phase(r);
     float mix_fac;
     if (mag_l == 0.0) {
         mix_fac = 1.0;
@@ -263,8 +265,19 @@ void main() {
     imageStore(out_img, ivec2(0, woven), out_col);
 }
 
+// TODO this mapping is suspicious
 float norm_tan(float unnormed) {
     return (unnormed + HAPI) / IPI;
+}
+
+// magnitude
+float mag(Complex c) {
+    return pow((pow(c.real, 2.0) + pow(c.imag, 2.0)), 0.5);
+}
+
+// phase
+float phase(Complex c) {
+    return c.real != 0.0 ? norm_tan(atan(c.imag / c.real)) : 0.0;
 }
 "
 

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -56,7 +56,7 @@ pub struct AudioTexSource {
 
 impl AudioTexSource {
     pub fn new(height: usize) -> Result<AudioTexSource, Box<dyn Error>> {
-        let padded_bins = height;
+        let padded_bins = height * 2;
         let tex_height = height;
         Ok(AudioTexSource { tex_height: height, bins: padded_bins })
     }
@@ -184,7 +184,7 @@ impl AudioTexTap {
                 assert_eq!(source.tex_height as u32 % channel_combine::LOCAL_SIZE_X, 0);
                 let dispatch_x = source.tex_height as u32 / channel_combine::LOCAL_SIZE_X;
                 let cb = cb
-                    .dispatch([dispatch_x, 1, 1], pipeline.clone(), set.clone(), push_constants
+                    .dispatch([dispatch_x, 1, 1], pipeline.clone(), set.clone(), push_constants)
                     .unwrap()
                     .build()
                     .unwrap();

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -360,9 +360,9 @@ void main() {
         }
     }
 
-    vec4 out_col = vec4(0.4 * (right_sum - 1.5), 
-                        0.1 * (pow(left_sum * right_sum, 0.5) - 4.0),
-                        0.8 *(left_sum - 3.0),
+    vec4 out_col = vec4(0.04 * (pow(left_sum * right_sum, 0.5) - 0.3),
+                        0.06 * (right_sum - 0.8),
+                        0.08 * (left_sum - 0.4),
                         1.0);
 
     imageStore(out_img, ivec2(0, woven), out_col);

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -300,7 +300,7 @@ void main() {
     float right_sum = 0.0;
 
     {
-        float freq_center = fft.min_freq * pow(fft.log_scale, float(woven + 0.1));
+        float freq_center = fft.min_freq * pow(fft.log_scale, float(woven));
 
         float freq_start = fft.min_freq * pow(fft.log_scale, float(woven) + 0.5);
         uint start_tidx = uint(freq_start / fft.lin_res);

--- a/src/mesmerize.rs
+++ b/src/mesmerize.rs
@@ -140,7 +140,7 @@ impl<'a, 'f: 'a> Framer<'a, 'f, MezFramer, MezState, MezResources> for MezFramer
         _r: &MezResources,
     ) -> Result<(MezFramer, MezState), Box<dyn Error>> {
         // creates a stream of image-futures we can use to copy to our fft_texture
-        let source = AudioTexSource::new(2048).unwrap();
+        let source = AudioTexSource::new(1024).unwrap();
         let tap =
             AudioTexTap::turn_on(source, swap_win.device.clone(), swap_win.window_queue.clone())
                 .unwrap();

--- a/src/mesmerize.rs
+++ b/src/mesmerize.rs
@@ -166,7 +166,7 @@ impl<'a, 'f: 'a> Framer<'a, 'f, MezFramer, MezState, MezResources> for MezFramer
 
         let fft_texture = StorageImage::new(
             swap_win.device.clone(),
-            Dimensions::Dim2d { width: 1024, height: 1024 },
+            Dimensions::Dim2d { width: 2048, height: 1024 },
             Format::R32G32B32A32Sfloat,
             Some(swap_win.window_queue.family()),
         )
@@ -295,7 +295,7 @@ impl<'a, 'f: 'a> Framer<'a, 'f, MezFramer, MezState, MezResources> for MezFramer
                 )
                 .unwrap();
             x += 1;
-            if x + 1 > 1024 {
+            if x + 1 > 2048 {
                 x = 0;
             }
             self.fft_tex_index = x;

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -81,6 +81,26 @@ void main() {
     }
 }
 
+pub mod uv_scroll_fsm {
+    vulkano_shaders::shader! {
+    ty: "fragment",
+        src: "
+#version 450
+
+layout(location = 0) in vec2 tex_coords;
+layout(location = 0) out vec4 f_color;
+layout(set = 0, binding = 0) uniform sampler2D tex;
+layout (push_constant) uniform PushConstant {
+    float offset_fac;
+} scroll;
+
+void main() {
+    vec2 scrolled_coords = vec2(scroll.offset_fac - float(tex_coords.x), tex_coords.y);
+    f_color = texture(tex, scrolled_coords);
+}"
+    }
+}
+
 pub mod diag_grad_vsm {
     vulkano_shaders::shader! {
         ty: "vertex",


### PR DESCRIPTION
The Rust FFT package has been pushed beyond it's maximum usable envelope.

While I can make adjustments to continue pasting together various FFT's, let's take a moment to review the fundamentals of FFT-like algorithms and throw shade at the DFT's first.

## FFT's, DFT's, and The Future

The DFT is basically a bandpass array made by multiplying sine waves by discrete input.  Multiply all bins by all data points and you get a DFT basically.

The FFT is some variation of factoring or simplifying the DFT using symmetry at every whole and half step or something.  It's not that miraculous when presented this way.

The trouble is that we want a logarithmic display to have reasonable presentation of baselines, high hats, and perhaps *even more focus* on the melodic regions where most of the visual action would be.  The O(n(log(n)) complexity is a total lie once you want to switch to logarithmic space.  It wasn't that good to begin with.

Because of the Nyquist limit and Heisenberg Uncertainty principle (semi-exaggerating)  the form of data we actually need to go into a given frame is more like:

```
Density of samples taken at any given frequency, going down in frequency:
.    20kHz
. .   10kHz
. . . .    5kHz
. . . . . . . .   2.5kHz
. . . . . . . . . . . . . . . .   1.25kHz

...and so on 
```
We want a non-uniform window simply because it takes very few samples to measure energy at high frequencies but requires a decent amount as you get down into the deep bass lines.

Also, because this is a streaming program, a large number of calculations are based on old data anyway. 

In hasty conclusion, canonical FFT's not designed for streaming and not designed for spectrographs are pretty bad and I'd like to move on to a custom FFT for our application, likely using a compute shader and liberating the audio stream from this one implementation of visual candy.


- [x] - Related issues are linked
- [x ] - Commit notes describe what high-level abstractions / schemes are used
- [x] - Every single commit successfully built on CI
- [x] - Changelog update added
- [x] - License headers or catalog entries [CATALOG.md](CATALOG.md)
- [x] - Double-emoji signature :taiwan: :taiwan: etc to affirm you read and agree to [CONTRIBUTING.md](CONTRIBUTING.md)

:snowboarder: :snowboarder: 